### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "fsps",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "astropy",
     "h5py"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "fsps",
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "astropy",
     "h5py"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "fsps",
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
     "astropy",
     "h5py"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "fsps",
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "astropy",
     "h5py"
 ]

--- a/src/rail/creation/engines/fsps_photometry_creator.py
+++ b/src/rail/creation/engines/fsps_photometry_creator.py
@@ -51,7 +51,7 @@ class FSPSPhotometryCreator(Creator):
     inputs = [("model", Hdf5Handle)]
     outputs = [("output", Hdf5Handle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """
         Initialize class.
         The _b and _c tuples for jax are composed of None or 0, depending on whether you don't or do want the
@@ -61,7 +61,7 @@ class FSPSPhotometryCreator(Creator):
         args:
         comm:
         """
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
         if not os.path.isdir(self.config.filter_folder):
             raise OSError("File {self.config.filter_folder} not found")

--- a/src/rail/creation/engines/fsps_photometry_creator.py
+++ b/src/rail/creation/engines/fsps_photometry_creator.py
@@ -61,7 +61,7 @@ class FSPSPhotometryCreator(Creator):
         args:
         comm:
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
         if not os.path.isdir(self.config.filter_folder):
             raise OSError("File {self.config.filter_folder} not found")

--- a/src/rail/creation/engines/fsps_sed_modeler.py
+++ b/src/rail/creation/engines/fsps_sed_modeler.py
@@ -209,7 +209,7 @@ class FSPSSedModeler(Modeler):
         comm:
 
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self._output_handle = None
 
         if self.config.min_wavelength < 0: # pragma: no cover

--- a/src/rail/creation/engines/fsps_sed_modeler.py
+++ b/src/rail/creation/engines/fsps_sed_modeler.py
@@ -198,7 +198,7 @@ class FSPSSedModeler(Modeler):
     # outputs = [("model", ModelHandle)]
     outputs = [("model", Hdf5Handle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """
         This function initializes the FSPSSedModeler class and checks that the provided parameters are within the
         allowed ranges.
@@ -209,7 +209,7 @@ class FSPSSedModeler(Modeler):
         comm:
 
         """
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self._output_handle = None
 
         if self.config.min_wavelength < 0: # pragma: no cover


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.